### PR TITLE
Check both x and y for equivalence

### DIFF
--- a/Roguelike/Point.h
+++ b/Roguelike/Point.h
@@ -54,10 +54,10 @@ namespace std{
 		}
 	};
 	inline bool operator == (const Point& lhs, const Point& rhs){
-		return (lhs.xVal == rhs.xVal) && (lhs.xVal == rhs.xVal);
+		return (lhs.xVal == rhs.xVal) && (lhs.yVal == rhs.yVal);
 	}
 	inline bool operator != (const Point& lhs, const Point& rhs){
-		return (lhs.xVal != rhs.xVal) || (lhs.xVal != rhs.xVal);
+		return (lhs.xVal != rhs.xVal) || (lhs.yVal != rhs.yVal);
 	}
 };
 


### PR DESCRIPTION
When comparing, == and != should check for both x and y equivalence rather than just x AND x.
